### PR TITLE
gtwvt: Quick Edit Mode

### DIFF
--- a/contrib/hbcurl/easy.c
+++ b/contrib/hbcurl/easy.c
@@ -1060,6 +1060,50 @@ HB_FUNC( CURL_EASY_SETOPT )
                }
                break;
             }
+            case HB_CURLOPT_HTTPPOST_FORM:
+            {
+               PHB_ITEM pArray = hb_param( 3, HB_IT_ARRAY );
+
+               if( pArray )
+               {
+                  HB_SIZE ulPos;
+                  HB_SIZE ulArrayLen = hb_arrayLen( pArray );
+
+                  for( ulPos = 0; ulPos < ulArrayLen; ++ulPos )
+                  {
+                     PHB_ITEM pSubArray = hb_arrayGetItemPtr( pArray, ulPos + 1 );
+
+                     int type = hb_arrayGetNI( pSubArray, 1 );
+
+                     switch( type )
+                     {
+                        case HB_CURLOPT_HTTPPOST_FORM_CONTENT:
+
+                           curl_formadd( &hb_curl->pHTTPPOST_First,
+                                         &hb_curl->pHTTPPOST_Last,
+                                         CURLFORM_COPYNAME, hb_arrayGetCPtr( pSubArray, 2 ),
+                                         CURLFORM_NAMELENGTH, hb_arrayGetCLen( pSubArray, 2 ),
+                                         CURLFORM_COPYCONTENTS, hb_arrayGetCPtr( pSubArray, 3 ),
+                                         CURLFORM_CONTENTSLENGTH, hb_arrayGetCLen( pSubArray, 3 ),
+                                         CURLFORM_END );
+
+                           break;
+                        case HB_CURLOPT_HTTPPOST_FORM_FILE:
+                           curl_formadd( &hb_curl->pHTTPPOST_First,
+                                         &hb_curl->pHTTPPOST_Last,
+                                         CURLFORM_COPYNAME, hb_arrayGetCPtr( pSubArray, 2 ),
+                                         CURLFORM_NAMELENGTH, hb_arrayGetCLen( pSubArray, 2 ),
+                                         CURLFORM_FILE, hb_curl_StrHash( hb_curl, hb_arrayGetCPtr( pSubArray, 3 ) ),
+                                         CURLFORM_END );
+                           break;
+                     }
+
+                  }
+
+                  res = curl_easy_setopt( hb_curl->curl, CURLOPT_HTTPPOST, hb_curl->pHTTPPOST_First );
+               }
+            }
+            break;
             case HB_CURLOPT_REFERER:
                res = curl_easy_setopt( hb_curl->curl, CURLOPT_REFERER, hb_curl_StrHash( hb_curl, hb_parc( 3 ) ) );
                break;

--- a/contrib/hbcurl/hbcurl.ch
+++ b/contrib/hbcurl/hbcurl.ch
@@ -279,6 +279,7 @@
 #define HB_CURLOPT_DL_BUFF_GET                1009
 #define HB_CURLOPT_UL_NULL_SETUP              1010
 #define HB_CURLOPT_HTTPPOST_CONTENT           1013
+#define HB_CURLOPT_HTTPPOST_FORM              1014
 #define HB_CURLOPT_PROGRESSBLOCK              HB_CURLOPT_XFERINFOBLOCK
 /* Compatibility ones. Please don't use these. */
 #define HB_CURLOPT_UL_FHANDLE_SETUP           HB_CURLOPT_UL_FILE_SETUP
@@ -604,5 +605,9 @@
 #define HB_CURLVERINFO_ICONV_VER_NUM          12
 #define HB_CURLVERINFO_LIBSSH_VERSION         13
 #define HB_CURLVERINFO_LEN                    13
+
+/* HB_CURLOPT_HTTPPOST_FORM type */
+#define HB_CURLOPT_HTTPPOST_FORM_CONTENT      1
+#define HB_CURLOPT_HTTPPOST_FORM_FILE         2
 
 #endif /* HBCURL_CH_ */

--- a/include/hbgtinfo.ch
+++ b/include/hbgtinfo.ch
@@ -151,6 +151,8 @@
 #define HB_GTI_CLOSEMODE        74  /* Close event: 0 terminate application, >=1 generate HB_K_CLOSE, 2 disable close button */
 #define HB_GTI_MINIMIZED        75  /* Get/Set Window's Minimized status (supported by: GTQTC, GTXWC) */
 
+#define HB_GTI_QUICKEDIT        76  /* Enable/Disable quick edit mode (supported by: GTWVT) */
+
 /* Font weights */
 #define HB_GTI_FONTW_THIN       1
 #define HB_GTI_FONTW_NORMAL     2

--- a/src/rtl/gtwvt/gtwvt.c
+++ b/src/rtl/gtwvt/gtwvt.c
@@ -2220,14 +2220,9 @@ static void hb_gt_wvt_MouseEvent( PHB_GTWVT pWVT, UINT message, WPARAM wParam, L
          if( pWVT->bQuickEdit )
          {
             HB_GT_INFO gtInfo;
+            memset( &gtInfo, 0, sizeof( gtInfo ) );
 
-            gtInfo.pNewVal  = NULL;
-            gtInfo.pNewVal2 = NULL;
-            gtInfo.pResult  = NULL;
-
-            if( HB_GTSELF_INFO( pWVT->pGT, HB_GTI_CLIPBOARDDATA, &gtInfo ) )
-               HB_GTSELF_INKEYSETTEXT( pWVT->pGT, hb_itemGetCPtr( gtInfo.pResult ),
-                                       hb_itemGetCLen( gtInfo.pResult ) );
+            hb_gtInfo( HB_GTI_CLIPBOARDPASTE, &gtInfo );
 
             hb_gt_wvt_Composited( pWVT, HB_FALSE );
 

--- a/src/rtl/gtwvt/gtwvt.h
+++ b/src/rtl/gtwvt/gtwvt.h
@@ -352,6 +352,8 @@ typedef struct
 
    RECT     ciLast;                       /* need in WM_ENTERSIZEMOVE processing and hb_gt_wvt_PaintText() function [HVB] */
 
+   HB_BOOL  bQuickEdit;
+
 } HB_GTWVT, * PHB_GTWVT;
 
 #ifndef WM_MOUSEWHEEL


### PR DESCRIPTION
Hi Viktor,

I added a new GT setting called HB_GTI_QUICKEDIT ( gtwvt )

If enabled it supports the "Quick Edit Mode" funcionality found in traditional windows console apps: left mouse button to select&copy, right mouse button to paste.

It doesn't break existing wvt code because the default is false.

I also had the re-add my previous fix for posting mixed content, multipart forms w/libcurl.
I couldn't find any better workaround to implement it ( HTTPOST_CONTENT doesn't work in that case). You can just ignore it if not interested.

Thanks

