### PR TITLE
2016-04-20 22:44 UTC+0200 Viktor Szakats (vszakats users.noreply.github.com)

### DIFF
--- a/contrib/hbmzip/mzip.c
+++ b/contrib/hbmzip/mzip.c
@@ -1250,7 +1250,7 @@ static int hb_unzipExtractCurrentFile( unzFile hUnzip, const char * szFileName, 
    else
    {
       pFile = hb_fileExtOpen( szName, NULL,
-                              FO_READWRITE | FO_EXCLUSIVE | FO_PRIVATE |
+                              FO_WRITE | FO_EXCLUSIVE | FO_PRIVATE |
                               FXO_TRUNCATE | FXO_SHARELOCK, NULL, NULL );
       if( pFile != NULL )
       {

--- a/contrib/xhb/xhbcopyf.c
+++ b/contrib/xhb/xhbcopyf.c
@@ -93,7 +93,7 @@ static HB_BOOL hb_copyfile( const char * pszSource, const char * pszDest, PHB_IT
       do
       {
          pDest = hb_fileExtOpen( pszDest, NULL,
-                                 FO_READWRITE | FO_EXCLUSIVE | FO_PRIVATE |
+                                 FO_WRITE | FO_EXCLUSIVE | FO_PRIVATE |
                                  FXO_TRUNCATE | FXO_DEFAULTS | FXO_SHARELOCK,
                                  NULL, pError );
          if( pDest == NULL )

--- a/src/rdd/delim1.c
+++ b/src/rdd/delim1.c
@@ -1422,7 +1422,7 @@ static HB_ERRCODE hb_delimCreate( DELIMAREAP pArea, LPDBOPENINFO pCreateInfo )
    do
    {
       pArea->pFile = hb_fileExtOpen( szFileName, NULL,
-                                     FO_READWRITE | FO_EXCLUSIVE | FXO_TRUNCATE |
+                                     FO_WRITE | FO_EXCLUSIVE | FXO_TRUNCATE |
                                      FXO_DEFAULTS | FXO_SHARELOCK | FXO_COPYNAME,
                                      NULL, pError );
       if( ! pArea->pFile )

--- a/src/rdd/hbsix/sxcompr.c
+++ b/src/rdd/hbsix/sxcompr.c
@@ -620,7 +620,7 @@ HB_FUNC( SX_FCOMPRESS )
                                         FXO_DEFAULTS | FXO_SHARELOCK, NULL, NULL );
       if( pInput != NULL )
       {
-         PHB_FILE pOutput = hb_fileExtOpen( szDestin, NULL, FO_READWRITE |
+         PHB_FILE pOutput = hb_fileExtOpen( szDestin, NULL, FO_WRITE |
                                             FO_EXCLUSIVE | FXO_TRUNCATE |
                                             FXO_DEFAULTS | FXO_SHARELOCK, NULL, NULL );
          if( pOutput != NULL )
@@ -655,7 +655,7 @@ HB_FUNC( SX_FDECOMPRESS )
                                         FXO_DEFAULTS | FXO_SHARELOCK, NULL, NULL );
       if( pInput != NULL )
       {
-         PHB_FILE pOutput = hb_fileExtOpen( szDestin, NULL, FO_READWRITE |
+         PHB_FILE pOutput = hb_fileExtOpen( szDestin, NULL, FO_WRITE |
                                             FO_EXCLUSIVE | FXO_TRUNCATE |
                                             FXO_DEFAULTS | FXO_SHARELOCK, NULL, NULL );
          if( pOutput != NULL )

--- a/src/rdd/sdf1.c
+++ b/src/rdd/sdf1.c
@@ -1078,7 +1078,7 @@ static HB_ERRCODE hb_sdfCreate( SDFAREAP pArea, LPDBOPENINFO pCreateInfo )
    do
    {
       pArea->pFile = hb_fileExtOpen( szFileName, NULL,
-                                     FO_READWRITE | FO_EXCLUSIVE | FXO_TRUNCATE |
+                                     FO_WRITE | FO_EXCLUSIVE | FXO_TRUNCATE |
                                      FXO_DEFAULTS | FXO_SHARELOCK | FXO_COPYNAME,
                                      NULL, pError );
       if( ! pArea->pFile )

--- a/src/rtl/copyfile.c
+++ b/src/rtl/copyfile.c
@@ -96,7 +96,7 @@ static HB_BOOL hb_copyfile( const char * pszSource, const char * pszDest )
       do
       {
          pDest = hb_fileExtOpen( pszDest, NULL,
-                                 FO_READWRITE | FO_EXCLUSIVE | FO_PRIVATE |
+                                 FO_WRITE | FO_EXCLUSIVE | FO_PRIVATE |
                                  FXO_TRUNCATE | FXO_DEFAULTS | FXO_SHARELOCK,
                                  NULL, pError );
          if( pDest == NULL )

--- a/src/rtl/fscopy.c
+++ b/src/rtl/fscopy.c
@@ -59,7 +59,7 @@ HB_BOOL hb_fsCopy( const char * pszSource, const char * pszDest )
       PHB_FILE pDstFile;
       HB_ERRCODE errCode;
 
-      if( ( pDstFile = hb_fileExtOpen( pszDest, NULL, FXO_TRUNCATE | FO_READWRITE | FO_EXCLUSIVE | FXO_SHARELOCK, NULL, NULL ) ) != NULL )
+      if( ( pDstFile = hb_fileExtOpen( pszDest, NULL, FXO_TRUNCATE | FO_WRITE | FO_EXCLUSIVE | FXO_SHARELOCK, NULL, NULL ) ) != NULL )
       {
          void * pbyBuffer = hb_xgrab( HB_FSCOPY_BUFFERSIZE );
 

--- a/src/rtl/memofile.c
+++ b/src/rtl/memofile.c
@@ -97,7 +97,7 @@ static HB_BOOL hb_memowrit( HB_BOOL bHandleEOF )
    if( pszFileName && pString )
    {
       PHB_FILE pFile = hb_fileExtOpen( pszFileName, NULL,
-                                       FO_READWRITE | FO_EXCLUSIVE | FO_PRIVATE |
+                                       FO_WRITE | FO_EXCLUSIVE | FO_PRIVATE |
                                        FXO_TRUNCATE | FXO_SHARELOCK,
                                        NULL, NULL );
 

--- a/src/vm/memvars.c
+++ b/src/vm/memvars.c
@@ -1455,7 +1455,7 @@ HB_FUNC( __MVSAVE )
       {
          fhnd = hb_fileExtOpen( pszFileName,
                                 hb_stackSetStruct()->HB_SET_DEFEXTENSIONS ? ".mem" : NULL,
-                                FXO_TRUNCATE | FO_READWRITE | FO_EXCLUSIVE |
+                                FXO_TRUNCATE | FO_WRITE | FO_EXCLUSIVE |
                                 FXO_DEFAULTS | FXO_SHARELOCK,
                                 NULL, pError );
          if( fhnd == NULL )


### PR DESCRIPTION
  * contrib/hbmzip/mzip.c
  * contrib/xhb/xhbcopyf.c
  * src/rdd/delim1.c
  * src/rdd/hbsix/sxcompr.c
  * src/rdd/sdf1.c
  * src/rtl/copyfile.c
  * src/rtl/fscopy.c
  * src/rtl/memofile.c
  * src/rtl/typefile.prg
  * src/vm/memvars.c
    % use FO_WRITE or FO_READ instead of FO_READWRITE where possible