### PR TITLE
recognize gcc 6.2.0

### DIFF
--- a/config/global.mk
+++ b/config/global.mk
@@ -950,6 +950,9 @@ ifeq ($(HB_COMPILER_VER),)
          HB_COMP_PATH_VER_DET := $(HB_CCPREFIX)gcc$(HB_CCSUFFIX)
       endif
       _C_VER := $(shell "$(HB_COMP_PATH_VER_DET)" -v 2>&1)
+      ifneq ($(findstring version 6.2.,$(_C_VER)),)
+         HB_COMPILER_VER := 0602
+      else
       ifneq ($(findstring version 6.1.,$(_C_VER)),)
          HB_COMPILER_VER := 0601
       else
@@ -987,6 +990,7 @@ ifeq ($(HB_COMPILER_VER),)
          HB_COMPILER_VER := 0403
       else
          HB_COMPILER_VER := 0304
+      endif
       endif
       endif
       endif


### PR DESCRIPTION
Updated gcc detection for mingw ( tested on msys2 - gcc 6.2.0)