### PR TITLE
harbour: remove the limitation to declare variables before executable…

### DIFF
--- a/src/compiler/hbmain.c
+++ b/src/compiler/hbmain.c
@@ -383,7 +383,7 @@ void hb_compVariableAdd( HB_COMP_DECL, const char * szVarName, PHB_VARTYPE pVarT
    /* check if we are declaring local/static variable after some
     * executable statements
     */
-   if( pFunc->funFlags & HB_FUNF_STATEMENTS )
+ /*  if( pFunc->funFlags & HB_FUNF_STATEMENTS )
    {
       const char * szVarScope;
       switch( HB_COMP_PARAM->iVarScope )
@@ -410,7 +410,7 @@ void hb_compVariableAdd( HB_COMP_DECL, const char * szVarName, PHB_VARTYPE pVarT
          return;
       }
    }
-
+*/
    /* Check if a declaration of duplicated variable name is requested */
    if( pFunc->szName )
    {


### PR DESCRIPTION
I'm not sure if these kind of patches are welcomed or not, but anyway just wanted to throw it out there.
One of the things that annoy me the most about Clipper 5 (and of course Harbour) is the fact that you need to define each and every LOCAL variable at the beginning of the scope. Removing this limitation is simple and I particularly don't see any side effect.
I know it's a trivial example, but nstead of:

```
FUNC Test()
   LOCAL a := 1
   LOCAL b := 2
   LOCAL c

   ... do some work ...

  c := <some result>
RETURN
```

You can write:

```
FUNC Test()
   LOCAL a := 1
   LOCAL b := 2
   
   ... do some work ...

  LOCAL c := <some result>
RETURN

```
It is very useful in combination with the preprocessor:

```
MENU oMenu1
   ITEM 'item1' ACTION action1()
  ITEM 'item2' ACTION action2()
ENDMENU

MENU oMenu2
  ITEM 'item1' ACTION action1()
ITEM 'item2' MENU oMenu1
ENDMENU
```

Could be translated to LOCAL variables defined in between executable code:

```
LOCAL oMenu1 := {}
AADD{oMenu1, {'Item1', {|| action1()}})
AADD{oMenu1, {'Item2', {|| action2()}})

LOCAL oMenu2 := {}
AADD{oMenu2, {'Item1', {|| action1()}})
AADD{oMenu2, {'Item2', oMenu1})

```
Anyways, I did the change and wanted to know if it's something you're interested in merging.
Cheers!