### PR TITLE
remove uneccessary variable

### DIFF
--- a/contrib/hbtip/tests/http_qry.prg
+++ b/contrib/hbtip/tests/http_qry.prg
@@ -11,7 +11,7 @@ PROCEDURE Main()
 
    LOCAL cURL := iif( tip_SSL(), "https", "http" ) + "://duckduckgo.com/html/"
    LOCAL oHTTP := TIPClientHTTP():New( cURL )
-   LOCAL cHtml, oNode, oDoc, tmp
+   LOCAL cHtml, oNode, oDoc
 
    ? "URL:", cURL
 


### PR DESCRIPTION
(fail to compile with: Warning W0003  Variable 'TMP' declared but not used in function)