### PR TITLE
Fix a bug in TIPClientHTTP:PostMultiPart that corrupt attached files

### DIFF
--- a/contrib/hbtip/httpcli.prg
+++ b/contrib/hbtip/httpcli.prg
@@ -550,7 +550,7 @@ METHOD PostMultiPart( xPostData, cQuery ) CLASS TIPClientHTTP
          hb_vfClose( hFile )
       ENDIF
 
-      cData := cCrlf
+      cData += cCrlf
    NEXT
 
    cData += cBound + "--" + cCrlf


### PR DESCRIPTION
  * contrib/hbtip/httpcli.prg
    ! fix a bug in TIPClientHTTP:PostMultiPart that corrupt attached files