### PR TITLE
darwin: fix `-O?` parameter with HB_BUILD_DEBUG=yes

### DIFF
--- a/config/common/clang.mk
+++ b/config/common/clang.mk
@@ -59,7 +59,7 @@ endif
 ifneq ($(HB_BUILD_OPTIM),no)
    ifeq ($(HB_BUILD_DEBUG),yes)
       ifeq ($(filter $(HB_COMPILER_VER),0304 0305 0306 0307 0308 0309),)
-         CFLAGS += -Og
+         CFLAGS += -O3
       else
          CFLAGS += -O1
       endif


### PR DESCRIPTION
building Harbour on Mac OS X with HB_BUILD_DEBUG=yes leads to a wrong compile optimizing parameter:  -Og


